### PR TITLE
Use React Hook Form with Zod

### DIFF
--- a/apps/backend/src/common/constants/response-codes.ts
+++ b/apps/backend/src/common/constants/response-codes.ts
@@ -2,32 +2,32 @@ import { HttpStatus } from '@nestjs/common';
 export const ResponseMeta = {
   Auth: {
     EmailAlreadyRegistered: {
-      code: 'auth.emailAlreadyRegistered',
+      code: 'AUTH_EMAIL_ALREADY_REGISTERED',
       message: 'Email is already registered',
       statusCode: HttpStatus.BAD_REQUEST,
     },
     SignupSuccess: {
-      code: 'auth.signup.success',
+      code: 'AUTH_SIGNUP_SUCCESS',
       message: 'Signed up successfully',
       statusCode: HttpStatus.CREATED,
     },
     LoginSuccess: {
-      code: 'auth.login.success',
+      code: 'AUTH_LOGIN_SUCCESS',
       message: 'Logged in successfully',
       statusCode: HttpStatus.OK,
     },
     InvalidCredentials: {
-      code: 'auth.invalidCredentials',
+      code: 'AUTH_INVALID_CREDENTIALS',
       message: 'Invalid credentials',
       statusCode: HttpStatus.UNAUTHORIZED,
     },
     PasswordResetSuccess: {
-      code: 'auth.passwordReset.success',
+      code: 'AUTH_PASSWORD_RESET_SUCCESS',
       message: 'Password has been reset',
       statusCode: HttpStatus.OK,
     },
     InvalidResetToken: {
-      code: 'auth.invalidToken',
+      code: 'AUTH_INVALID_TOKEN',
       message: 'Invalid email or token',
       statusCode: HttpStatus.UNAUTHORIZED,
     },

--- a/apps/backend/src/common/interceptors/response/response.interceptor.ts
+++ b/apps/backend/src/common/interceptors/response/response.interceptor.ts
@@ -9,7 +9,7 @@ export class ResponseInterceptor implements NestInterceptor {
       map((response) => {
         return {
           success: true,
-          code: response?.code || 'success.default',
+          code: response?.code || 'SUCCESS_DEFAULT',
           message: response?.message || 'Success',
           data: response?.data ?? response,
         };

--- a/apps/frontend/lib/api/error-handler.ts
+++ b/apps/frontend/lib/api/error-handler.ts
@@ -1,13 +1,32 @@
-export function mapSignupErrorCode(
+export function mapAuthErrorCode(
   code: string,
   t: (key: string) => string,
 ): { field?: string; message: string } | null {
   switch (code) {
-    case 'auth.emailAlreadyRegistered':
-      return { field: 'email', message: t('auth.errorCodes.EMAIL_ALREADY_EXISTS') };
-    case 'auth.weakPassword':
-      return { field: 'password', message: t('auth.errorCodes.WEAK_PASSWORD') };
+    case 'AUTH_EMAIL_ALREADY_REGISTERED':
+      return {
+        field: 'email',
+        message: t('auth.errorCodes.AUTH_EMAIL_ALREADY_REGISTERED'),
+      };
+    case 'AUTH_WEAK_PASSWORD':
+      return {
+        field: 'password',
+        message: t('auth.errorCodes.AUTH_WEAK_PASSWORD'),
+      };
+    case 'AUTH_USER_NOT_FOUND':
+      return {
+        field: 'email',
+        message: t('auth.errorCodes.AUTH_USER_NOT_FOUND'),
+      };
+    case 'AUTH_INVALID_CREDENTIALS':
+      return {
+        field: 'password',
+        message: t('auth.errorCodes.AUTH_INVALID_CREDENTIALS'),
+      };
     default:
       return null;
   }
 }
+
+export const mapSignupErrorCode = mapAuthErrorCode;
+export const mapLoginErrorCode = mapAuthErrorCode;

--- a/apps/frontend/lib/dictionaries/en.ts
+++ b/apps/frontend/lib/dictionaries/en.ts
@@ -88,6 +88,11 @@ export default {
       INVALID_CREDENTIALS: 'Incorrect email or password.',
       USER_NOT_FOUND: 'User not found.',
       WEAK_PASSWORD: 'Password is too weak.',
+      AUTH_EMAIL_ALREADY_REGISTERED: 'This email is already registered.',
+      AUTH_INVALID_CREDENTIALS: 'Incorrect email or password.',
+      AUTH_USER_NOT_FOUND: 'User not found.',
+      AUTH_WEAK_PASSWORD: 'Password is too weak.',
+      AUTH_INVALID_TOKEN: 'Invalid token.',
     },
   },
   user: {

--- a/apps/frontend/lib/dictionaries/th.ts
+++ b/apps/frontend/lib/dictionaries/th.ts
@@ -88,6 +88,11 @@ export default {
       INVALID_CREDENTIALS: 'อีเมลหรือรหัสผ่านไม่ถูกต้อง',
       USER_NOT_FOUND: 'ไม่พบบัญชีผู้ใช้',
       WEAK_PASSWORD: 'รหัสผ่านไม่ปลอดภัยเพียงพอ',
+      AUTH_EMAIL_ALREADY_REGISTERED: 'อีเมลนี้ถูกใช้ไปแล้ว',
+      AUTH_INVALID_CREDENTIALS: 'อีเมลหรือรหัสผ่านไม่ถูกต้อง',
+      AUTH_USER_NOT_FOUND: 'ไม่พบบัญชีผู้ใช้',
+      AUTH_WEAK_PASSWORD: 'รหัสผ่านไม่ปลอดภัยเพียงพอ',
+      AUTH_INVALID_TOKEN: 'โทเคนไม่ถูกต้อง',
     },
   },
   user: {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -26,6 +26,9 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.50.0",
+    "@hookform/resolvers": "^3.3.4",
+    "zod": "^3.22.4",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add form libraries to frontend deps
- implement zod + react-hook-form in login form
- implement zod + react-hook-form in signup form
- use constant-case codes across backend and frontend
- centralize auth error code mapping and use it in login

## Testing
- `pnpm --filter frontend run lint` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_684b915bc9b8832aaa8f47e588aec8a7