### PR TITLE
Add password reset email flow

### DIFF
--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -7,12 +7,14 @@ import { User } from 'src/users/entities/user.entity';
 import { AuthController } from './controllers/auth.controller';
 import { AuthService } from './services/auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
+import { MailModule } from '../mail/mail.module';
 
 @Module({
   imports: [
     ConfigModule,
     TypeOrmModule.forFeature([User]),
     PassportModule,
+    MailModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/apps/backend/src/auth/controllers/auth.controller.ts
+++ b/apps/backend/src/auth/controllers/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post } from '@nestjs/common';
 import { LoginDto } from '../dto/login.dto';
 import { ResetPasswordDto } from '../dto/reset-password.dto';
 import { SignupDto } from '../dto/signup.dto';
+import { RequestPasswordDto } from '../dto/request-password.dto';
 import { AuthService } from '../services/auth.service';
 
 @Controller('auth')
@@ -21,5 +22,10 @@ export class AuthController {
   @Post('reset-password')
   resetPassword(@Body() dto: ResetPasswordDto) {
     return this.authService.resetPassword(dto);
+  }
+
+  @Post('request-password-reset')
+  requestReset(@Body() dto: RequestPasswordDto) {
+    return this.authService.requestPasswordReset(dto);
   }
 }

--- a/apps/backend/src/auth/dto/request-password.dto.ts
+++ b/apps/backend/src/auth/dto/request-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class RequestPasswordDto {
+  @IsEmail()
+  email: string;
+}

--- a/apps/backend/src/common/constants/response-codes.ts
+++ b/apps/backend/src/common/constants/response-codes.ts
@@ -26,6 +26,11 @@ export const ResponseMeta = {
       message: 'Password has been reset',
       statusCode: HttpStatus.OK,
     },
+    ResetEmailSent: {
+      code: 'AUTH_RESET_EMAIL_SENT',
+      message: 'Password reset email sent',
+      statusCode: HttpStatus.OK,
+    },
     InvalidResetToken: {
       code: 'AUTH_INVALID_TOKEN',
       message: 'Invalid email or token',

--- a/apps/backend/src/mail/mail.module.ts
+++ b/apps/backend/src/mail/mail.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { MailService } from './mail.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [MailService],
+  exports: [MailService],
+})
+export class MailModule {}

--- a/apps/backend/src/mail/mail.service.ts
+++ b/apps/backend/src/mail/mail.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+
+@Injectable()
+export class MailService {
+  private transporter: nodemailer.Transporter;
+
+  constructor(private readonly config: ConfigService) {
+    const host = this.config.get<string>('SMTP_HOST');
+    const port = this.config.get<number>('SMTP_PORT');
+    const user = this.config.get<string>('SMTP_USER');
+    const pass = this.config.get<string>('SMTP_PASS');
+
+    if (host && port && user && pass) {
+      this.transporter = nodemailer.createTransport({
+        host,
+        port,
+        auth: { user, pass },
+      });
+    } else {
+      // For development, create a test account
+      nodemailer.createTestAccount().then((acc) => {
+        this.transporter = nodemailer.createTransport({
+          host: acc.smtp.host,
+          port: acc.smtp.port,
+          secure: acc.smtp.secure,
+          auth: { user: acc.user, pass: acc.pass },
+        });
+        Logger.log(`Test mail account created: ${acc.user}`);
+      });
+    }
+  }
+
+  async sendPasswordReset(to: string, token: string) {
+    const appUrl = this.config.get<string>('APP_URL') || 'http://localhost:3001';
+    const resetLink = `${appUrl}/auth/reset-password?token=${token}&email=${encodeURIComponent(to)}`;
+    const message = {
+      from: this.config.get<string>('SMTP_FROM', 'noreply@example.com'),
+      to,
+      subject: 'Reset your password',
+      text: `Click the following link to reset your password: ${resetLink}`,
+      html: `<p>Click the following link to reset your password:</p><p><a href="${resetLink}">${resetLink}</a></p>`,
+    };
+
+    const info = await this.transporter.sendMail(message);
+    if (nodemailer.getTestMessageUrl(info)) {
+      Logger.log(`Preview URL: ${nodemailer.getTestMessageUrl(info)}`);
+    }
+  }
+}

--- a/apps/frontend/lib/api/auth.ts
+++ b/apps/frontend/lib/api/auth.ts
@@ -20,6 +20,10 @@ type ResetPasswordDto = {
   token: string;
 };
 
+type RequestPasswordResetDto = {
+  email: string;
+};
+
 export async function login(data: LoginDto) {
   const res = await api.post(`${API_BASE}/auth/login`, data);
   return res.data;
@@ -32,5 +36,10 @@ export async function signup(data: SignupDto) {
 
 export async function resetPassword(data: ResetPasswordDto) {
   const res = await api.post(`${API_BASE}/auth/reset-password`, data);
+  return res.data;
+}
+
+export async function requestPasswordReset(data: RequestPasswordResetDto) {
+  const res = await api.post(`${API_BASE}/auth/request-password-reset`, data);
   return res.data;
 }

--- a/apps/frontend/lib/dictionaries/en.ts
+++ b/apps/frontend/lib/dictionaries/en.ts
@@ -93,6 +93,7 @@ export default {
       AUTH_USER_NOT_FOUND: 'User not found.',
       AUTH_WEAK_PASSWORD: 'Password is too weak.',
       AUTH_INVALID_TOKEN: 'Invalid token.',
+      AUTH_RESET_EMAIL_SENT: 'Password reset email sent.',
     },
   },
   user: {

--- a/apps/frontend/lib/dictionaries/th.ts
+++ b/apps/frontend/lib/dictionaries/th.ts
@@ -93,6 +93,7 @@ export default {
       AUTH_USER_NOT_FOUND: 'ไม่พบบัญชีผู้ใช้',
       AUTH_WEAK_PASSWORD: 'รหัสผ่านไม่ปลอดภัยเพียงพอ',
       AUTH_INVALID_TOKEN: 'โทเคนไม่ถูกต้อง',
+      AUTH_RESET_EMAIL_SENT: 'ส่งอีเมลรีเซ็ตรหัสผ่านแล้ว',
     },
   },
   user: {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "packageManager": "pnpm@10.11.0",
   "dependencies": {
     "bcryptjs": "^3.0.2",
-    "pg": "^8.16.0"
+    "pg": "^8.16.0",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/nprogress": "^0.2.3"


### PR DESCRIPTION
## Summary
- add nodemailer dependency
- implement MailModule and MailService using Nodemailer
- support password reset email request and token validation
- expose new `/auth/request-password-reset` endpoint
- update frontend API and form to call new endpoint
- extend dictionaries with reset email message

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_684ba03468ec832aa91c411519f736ef