### PR TITLE
Update verify email page styling

### DIFF
--- a/apps/frontend/app/auth/verify-email/page.tsx
+++ b/apps/frontend/app/auth/verify-email/page.tsx
@@ -1,18 +1,33 @@
 'use client'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Mail } from 'lucide-react'
 import Link from 'next/link'
 import { useTranslation } from '@/lib/i18n'
 import { verifyEmail } from '@/lib/api/auth'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
-const containerClass = 'bg-muted flex min-h-svh flex-col items-center justify-center p-6 md:p-10'
+const containerClass =
+  'bg-muted flex min-h-svh flex-col items-center justify-center p-6 md:p-10'
 const wrapperClass = 'w-full max-w-md'
-const cardClass = 'p-8 text-center flex flex-col gap-4'
-const messageClass = 'text-lg'
-const buttonClass = 'mt-4'
-const linkClass = 'underline underline-offset-4'
+const headerClass = 'text-center'
+const titleClass = 'text-2xl'
+const contentClass = 'flex flex-col items-center space-y-4 pt-4'
+const iconWrapperClass = 'rounded-full bg-primary/20 p-3'
+const iconClass = 'h-6 w-6 text-primary'
+const messageClass = 'text-center text-sm text-muted-foreground'
+const resendWrapperClass = 'text-center text-sm text-muted-foreground'
+const resendLinkClass = 'text-primary underline-offset-4 hover:underline'
+const footerClass = 'flex flex-col space-y-2'
+const buttonClass = 'w-full'
 
 export default function VerifyEmailPage() {
   const { t } = useTranslation()
@@ -37,19 +52,35 @@ export default function VerifyEmailPage() {
     <div className={containerClass}>
       <div className={wrapperClass}>
         <Card>
-          <CardContent className={cardClass}>
-            {status === 'error' ? (
-              <p className={messageClass}>{t('onboarding.verifyEmail')}</p>
-            ) : (
+          <CardHeader className={headerClass}>
+            <CardTitle className={titleClass}>
+              {t('onboarding.verifyEmailAddress')}
+            </CardTitle>
+            <CardDescription>{t('onboarding.verifyEmail')}</CardDescription>
+          </CardHeader>
+          <CardContent className={contentClass}>
+            <div className={iconWrapperClass}>
+              <Mail className={iconClass} />
+            </div>
+            {status === 'error' && (
               <p className={messageClass}>{t('onboarding.verifyEmail')}</p>
             )}
-            <Link href="#" className={linkClass}>
-              {t('onboarding.resendEmail')}
-            </Link>
-            <Button asChild className={buttonClass}>
-              <Link href="/onboarding/setup">{t('onboarding.goToLogin')}</Link>
-            </Button>
+            <div className={resendWrapperClass}>
+              <Link href="#" className={resendLinkClass}>
+                {t('onboarding.resendEmail')}
+              </Link>
+            </div>
           </CardContent>
+          <CardFooter className={footerClass}>
+            <Button asChild className={buttonClass}>
+              <Link href="/onboarding/setup">
+                {t('onboarding.continueToDashboard')}
+              </Link>
+            </Button>
+            <Button variant="outline" asChild className={buttonClass}>
+              <Link href="/auth/login">{t('onboarding.goToLogin')}</Link>
+            </Button>
+          </CardFooter>
         </Card>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle verify email page using shadcn components and constants

## Testing
- `pnpm lint` *(fails: Request was cancelled - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684bcd290f2c832aa791fb43c45da64c