### PR TITLE
Add more timezone options

### DIFF
--- a/apps/frontend/app/onboarding/setup/page.tsx
+++ b/apps/frontend/app/onboarding/setup/page.tsx
@@ -100,7 +100,10 @@ export default function SetupPage() {
                         />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="asia_bangkok">Asia/Bangkok</SelectItem>
+                        <SelectItem value="asia_bangkok">UTC+7 Asia/Bangkok</SelectItem>
+                        <SelectItem value="asia_singapore">UTC+8 Asia/Singapore</SelectItem>
+                        <SelectItem value="asia_kuala_lumpur">UTC+8 Asia/Kuala_Lumpur</SelectItem>
+                        <SelectItem value="asia_jakarta">UTC+7 Asia/Jakarta</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>


### PR DESCRIPTION
## Summary
- expand timezone dropdown in onboarding setup with UTC offsets

## Testing
- `pnpm --filter frontend lint` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684bd5b45c8c832aa08c4b3dd873f99e